### PR TITLE
Fix HOTP key encoding from ascii to utf8

### DIFF
--- a/src/util/hotp.ts
+++ b/src/util/hotp.ts
@@ -3,14 +3,14 @@ import { createHmac } from 'node:crypto';
 /**
  * Generates a full HMAC-SHA1 HOTP token (40-char hex) for a given counter.
  * Unlike standard HOTP which truncates to 6-8 digits, this returns the full digest.
- * @param key - The shared secret key (ASCII).
+ * @param key - The shared secret key.
  * @param counter - The counter value.
  */
 export function generateHotpByCounter(key: string, counter: number): string {
   const counterBuffer = Buffer.alloc(8);
   counterBuffer.writeBigUInt64BE(BigInt(counter));
 
-  return createHmac('sha1', Buffer.from(key, 'ascii'))
+  return createHmac('sha1', Buffer.from(key, 'utf8'))
     .update(counterBuffer)
     .digest('hex');
 }


### PR DESCRIPTION
## Summary
- Change `Buffer.from(key, 'ascii')` to `Buffer.from(key, 'utf8')` in HOTP implementation
- Aligns with the SAPI MCP server implementation and correctly handles non-ASCII characters in shared secrets

Closes #1

## Test plan
- [x] All 124 existing tests pass
- [ ] Verify authentication still works with existing shared secrets

🤖 Generated with [Claude Code](https://claude.com/claude-code)