### PR TITLE
Fix create-release workflow token

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Validate branch
         run: |
@@ -26,7 +28,7 @@ jobs:
       - name: Determine version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.GLOBAL_ACTION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           MAJOR_MINOR="${GITHUB_REF_NAME#release/v}"
 
@@ -54,7 +56,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GLOBAL_ACTION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --target "${{ github.ref_name }}" \


### PR DESCRIPTION
## Summary
- Replace `secrets.GLOBAL_ACTION_TOKEN` with `github.token` (the secret is not configured for this repo)
- Add explicit `contents: write` permission for creating releases

Fixes the failed run: https://github.com/bluebillywig/bb-sapi-node-sdk/actions/runs/23341505144

## Test plan
- [ ] Re-run create-release workflow from `release/v1.0` after merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)