### PR TITLE
[release/v1.0] Fix create-release workflow: use github.token instead of missing secret

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -10,6 +10,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Validate branch
         run: |
@@ -26,7 +28,7 @@ jobs:
       - name: Determine version
         id: version
         env:
-          GH_TOKEN: ${{ secrets.GLOBAL_ACTION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           MAJOR_MINOR="${GITHUB_REF_NAME#release/v}"
 
@@ -54,7 +56,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ secrets.GLOBAL_ACTION_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --target "${{ github.ref_name }}" \


### PR DESCRIPTION
The GLOBAL_ACTION_TOKEN secret is not configured for this repo, causing the workflow to fail with a 401. Use the built-in github.token and add explicit contents: write permission.