### PR TITLE
Use PAT in create-release workflow to trigger publish

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Determine version
         id: version
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
         run: |
           MAJOR_MINOR="${GITHUB_REF_NAME#release/v}"
 
@@ -56,7 +56,7 @@ jobs:
 
       - name: Create GitHub Release
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_GITHUB_TOKEN }}
         run: |
           gh release create "${{ steps.version.outputs.tag }}" \
             --target "${{ github.ref_name }}" \


### PR DESCRIPTION
## Summary
- Use `PAT_GITHUB_TOKEN` secret instead of `github.token` in the create-release workflow
- The default `GITHUB_TOKEN` doesn't trigger other workflows (GitHub security feature), so the publish workflow was not running after a release was created

## Test plan
- [ ] Run create-release from `release/v1.0` and verify the publish workflow triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)