### PR TITLE
Fix executeUpload on Node 18+ — send a sized buffer body, not a stream

### DIFF
--- a/src/entities/media-clip.ts
+++ b/src/entities/media-clip.ts
@@ -1,6 +1,5 @@
 import { stat } from 'node:fs/promises';
 import { createReadStream } from 'node:fs';
-import { Readable } from 'node:stream';
 import { basename, extname } from 'node:path';
 import { Entity } from '../entity.js';
 import { SapiResponse } from '../response.js';
@@ -214,11 +213,21 @@ export class MediaClip extends Entity implements Listable, Gettable, Creatable<M
     const chunkSize = presignedUrl.chunkSize ?? fileStat.size;
     const offset = presignedUrl.offset ?? 0;
 
+    // Read the chunk into a buffer so the PUT carries a Content-Length and no
+    // chunked Transfer-Encoding. A streamed body sends Transfer-Encoding:
+    // chunked, which the S3 presigned PUT rejects (501 NotImplemented), and on
+    // Node 18+/undici a streamed body also requires duplex:'half'. Buffering a
+    // single bounded chunk (one multipart part, or a whole small single-chunk
+    // file) sidesteps both without holding more than one chunk in memory.
     const nodeStream = createReadStream(mediaClipPath, {
       start: offset,
       end: offset + chunkSize - 1,
     });
-    const body = Readable.toWeb(nodeStream) as ReadableStream;
+    const parts: Buffer[] = [];
+    for await (const part of nodeStream) {
+      parts.push(part as Buffer);
+    }
+    const body = Buffer.concat(parts);
 
     return this.sdk.sendRequest('PUT', presignedUrl.presignedUrl, { body });
   }

--- a/tests/entities/media-clip.test.ts
+++ b/tests/entities/media-clip.test.ts
@@ -244,6 +244,36 @@ describe('MediaClip', () => {
       }
     });
 
+    it('sends a sized buffer body (not a stream) so S3 gets a Content-Length', async () => {
+      const { fetch, calls } = createMockFetch([{ status: 200 }]);
+      const sdk = new Sdk('my-publication', new EmptyAuthenticator(), { fetch });
+
+      const tmp = makeTempFile();
+      await writeFile(tmp.path, Buffer.alloc(10, 0x41));
+
+      try {
+        await sdk.mediaclip.executeUpload(tmp.path, {
+          chunks: 1,
+          presignedUrls: [
+            {
+              presignedUrl: 'https://s3.example.com/presigned-url',
+              chunkSize: 10,
+            },
+          ],
+        });
+
+        // A streamed body forces Transfer-Encoding: chunked (rejected by S3
+        // presigned PUT with 501) and needs duplex:'half' on Node 18+. The
+        // upload must send a buffer so fetch sets a Content-Length instead.
+        const body = calls[0].init?.body;
+        expect(Buffer.isBuffer(body)).toBe(true);
+        expect((body as Buffer).length).toBe(10);
+        expect(calls[0].init).not.toHaveProperty('duplex');
+      } finally {
+        await tmp.cleanup();
+      }
+    });
+
     it('should default chunkSize to file size when not specified', async () => {
       const { fetch, calls } = createMockFetch([{ status: 200 }]);
       const sdk = new Sdk('my-publication', new EmptyAuthenticator(), { fetch });


### PR DESCRIPTION
## Problem

`mediaclip.executeUpload()` fails against S3 on Node 18+/undici. `performUpload` sent the upload body as a web `ReadableStream`, which breaks two ways:

1. `fetch` throws `TypeError: RequestInit: duplex option is required when sending a body` — `sendRequest` never sets `duplex: 'half'` for a stream body.
2. With `duplex` set, undici sends `Transfer-Encoding: chunked`, which the **S3 presigned PUT rejects** with `501 NotImplemented` ("A header you provided implies functionality that is not implemented: Transfer-Encoding") — S3 requires a `Content-Length`.

Net effect: uploads are unusable on Node 18+ (both the single-chunk and multipart paths go through the same streamed body).

## Fix

Read the bounded chunk into a `Buffer` and send that as the body. `fetch`/undici then sets `Content-Length`, with no chunked encoding and no `duplex` requirement. Only ever one bounded chunk is held in memory (a single multipart part, or a small single-chunk file), so the original "no full-file buffering" property is preserved.

Also removes the now-unused `Readable` import.

## Testing

- `tsc --noEmit` clean.
- Full suite: 125 passing, incl. a new regression test asserting the PUT body is a sized `Buffer` (not a stream) and carries no `duplex`.

## Note

Pre-existing (not introduced here): an empty file / `chunkSize: 0` makes `createReadStream`'s `end: offset + chunkSize - 1` go to `-1` and throw — same as the old streamed code. Out of scope for this fix; easy to guard later if desired.

ADO #19470

🤖 Generated with [Claude Code](https://claude.com/claude-code)